### PR TITLE
Expand habit types, add Achievements/History pages, exports, reminders, archiving

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,6 +10,7 @@ body {
 
 :root[data-theme="dark"] body {
   background:
+    radial-gradient(ellipse 60% 50% at 50% 8%, rgba(240, 180, 41, 0.09), transparent 70%),
     radial-gradient(ellipse at top, rgba(255, 255, 255, 0.03), transparent 60%),
     linear-gradient(160deg, #14121c, #0b0a11 70%);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,11 @@ import * as HabitHelper from "./Helpers/HabitHelper.js";
 import Home from "./Components/HomePage/Home.jsx";
 import Info from "./Components/HomePage/Info.jsx";
 import Stats from "./Components/Stats.jsx";
+import Achievements from "./Components/Achievements.jsx";
+import History from "./Components/History.jsx";
 import * as SettingsHelper from "./Helpers/SettingsHelper.js";
+import * as CompletionHelper from "./Helpers/CompletionHelper.js";
+import * as ReminderHelper from "./Helpers/ReminderHelper.js";
 
 export default function App() {
   const [user, setUser] = useState(null);
@@ -31,6 +35,36 @@ export default function App() {
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", displayMode);
   }, [displayMode]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const checkReminders = async () => {
+      const { enabled } = ReminderHelper.getReminderSettings(user.id);
+      if (!enabled) return;
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const [rawHabits, todaysCompletions] = await Promise.all([
+        HabitHelper.getHabitsByUserId(user.id),
+        CompletionHelper.getCompletionsByUserIdAndDate(user.id, today),
+      ]);
+      const habits = rawHabits.map(HabitHelper.mapHabit);
+      const completedIds = new Set(todaysCompletions.map((c) => c.habit_id));
+
+      const incompleteNames = habits
+        .filter((h) => !h.archived)
+        .filter((h) => h.recurrence.days.includes(today.getDay()))
+        .filter((h) => !completedIds.has(h.id))
+        .map((h) => h.name);
+
+      ReminderHelper.maybeNotify(user.id, incompleteNames);
+    };
+
+    const interval = setInterval(checkReminders, 60000);
+    return () => clearInterval(interval);
+  }, [user?.id]);
 
   const onLoginSuccess = async (user) => {
     setUser({ ...user, id: user.user_id });
@@ -125,6 +159,16 @@ export default function App() {
                 {rightPageView === "glance" && (
                   <div className="placeholder-page">
                     <AtAGlance user={user} selectedDate={selectedDate} />
+                  </div>
+                )}
+                {rightPageView === "history" && (
+                  <div className="placeholder-page">
+                    <History user={user} />
+                  </div>
+                )}
+                {rightPageView === "achievements" && (
+                  <div className="placeholder-page">
+                    <Achievements user={user} />
                   </div>
                 )}
                 {rightPageView === "signup" && (

--- a/src/Components/Achievements.jsx
+++ b/src/Components/Achievements.jsx
@@ -1,0 +1,198 @@
+import { useState, useEffect } from "react";
+import * as HabitHelper from "../Helpers/HabitHelper.js";
+import * as CompletionHelper from "../Helpers/CompletionHelper.js";
+import { findStreaks, formatDate } from "../Helpers/StreakHelper.js";
+import "../Style/Achievements.css";
+
+const BADGES = [
+  {
+    id: "first-step",
+    icon: "🌱",
+    label: "First Steps",
+    description: "Complete a habit for the first time.",
+    check: (ctx) => ctx.totalCompletions >= 1,
+  },
+  {
+    id: "streak-3",
+    icon: "🔥",
+    label: "3-Day Streak",
+    description: "Hit a 3-day streak on any habit.",
+    check: (ctx) => ctx.maxLongestStreak >= 3,
+  },
+  {
+    id: "streak-7",
+    icon: "🔥",
+    label: "One Week Strong",
+    description: "Hit a 7-day streak on any habit.",
+    check: (ctx) => ctx.maxLongestStreak >= 7,
+  },
+  {
+    id: "streak-14",
+    icon: "🔥",
+    label: "Two Weeks In",
+    description: "Hit a 14-day streak on any habit.",
+    check: (ctx) => ctx.maxLongestStreak >= 14,
+  },
+  {
+    id: "streak-30",
+    icon: "🏆",
+    label: "30-Day Streak",
+    description: "Hit a 30-day streak on any habit.",
+    check: (ctx) => ctx.maxLongestStreak >= 30,
+  },
+  {
+    id: "streak-60",
+    icon: "🏆",
+    label: "60-Day Streak",
+    description: "Hit a 60-day streak on any habit.",
+    check: (ctx) => ctx.maxLongestStreak >= 60,
+  },
+  {
+    id: "streak-100",
+    icon: "💎",
+    label: "Centurion Streak",
+    description: "Hit a 100-day streak on any habit.",
+    check: (ctx) => ctx.maxLongestStreak >= 100,
+  },
+  {
+    id: "completions-50",
+    icon: "⭐",
+    label: "50 Completions",
+    description: "Complete habits 50 times, all-time.",
+    check: (ctx) => ctx.totalCompletions >= 50,
+  },
+  {
+    id: "completions-100",
+    icon: "🌟",
+    label: "Century Club",
+    description: "Complete habits 100 times, all-time.",
+    check: (ctx) => ctx.totalCompletions >= 100,
+  },
+  {
+    id: "completions-500",
+    icon: "👑",
+    label: "500 Club",
+    description: "Complete habits 500 times, all-time.",
+    check: (ctx) => ctx.totalCompletions >= 500,
+  },
+  {
+    id: "perfect-week",
+    icon: "✅",
+    label: "Perfect Week",
+    description: "Complete every scheduled habit for 7 days straight.",
+    check: (ctx) => ctx.perfectWeek,
+  },
+  {
+    id: "collector",
+    icon: "📚",
+    label: "Habit Collector",
+    description: "Create 5 or more habits.",
+    check: (ctx) => ctx.habitCount >= 5,
+  },
+  {
+    id: "variety",
+    icon: "🎨",
+    label: "Mix It Up",
+    description: "Use 3 or more different habit types.",
+    check: (ctx) => ctx.typesUsed >= 3,
+  },
+];
+
+const PLACEHOLDER_EARNED = new Set(["first-step", "streak-3", "streak-7", "collector"]);
+
+export default function Achievements({ user }) {
+  const [habits, setHabits] = useState([]);
+  const [completions, setCompletions] = useState([]);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  useEffect(() => {
+    if (!user) return;
+    const load = async () => {
+      const [rawHabits, allCompletions] = await Promise.all([
+        HabitHelper.getHabitsByUserId(user.id),
+        CompletionHelper.getCompletionsByUserId(user.id),
+      ]);
+      setHabits(rawHabits.map(HabitHelper.mapHabit));
+      setCompletions(allCompletions);
+    };
+    load();
+  }, [user?.id]);
+
+  const computeContext = () => {
+    const totalCompletions = completions.length;
+    const maxLongestStreak = habits.reduce((max, habit) => {
+      const { longestStreak } = findStreaks(habit, completions, today);
+      return Math.max(max, longestStreak);
+    }, 0);
+
+    const last7 = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(today);
+      d.setDate(d.getDate() - i);
+      return d;
+    });
+    const completionDatesByHabit = {};
+    habits.forEach((habit) => {
+      completionDatesByHabit[habit.id] = new Set(
+        completions.filter((c) => c.habit_id === habit.id).map((c) => c.date),
+      );
+    });
+    const perfectWeek =
+      habits.length > 0 &&
+      last7.every((day) =>
+        habits
+          .filter((h) => !h.archived && h.recurrence.days.includes(day.getDay()))
+          .every((h) => completionDatesByHabit[h.id]?.has(formatDate(day))),
+      );
+
+    return {
+      totalCompletions,
+      maxLongestStreak,
+      perfectWeek,
+      habitCount: habits.length,
+      typesUsed: new Set(habits.map((h) => h.type)).size,
+    };
+  };
+
+  const renderBadge = (badge, earned) => (
+    <div
+      key={badge.id}
+      className={`badge-tile${earned ? " badge-tile--earned" : " badge-tile--locked"}`}
+    >
+      <span className="badge-icon">{earned ? badge.icon : "🔒"}</span>
+      <span className="badge-label">{badge.label}</span>
+      <span className="badge-description">{badge.description}</span>
+    </div>
+  );
+
+  if (!user) {
+    return (
+      <div className="achievements-page">
+        <h2 className="achievements-title">Achievements</h2>
+        <p className="achievements-no-user">
+          Log in to start earning achievements.
+        </p>
+        <div className="badge-grid">
+          {BADGES.map((badge) => renderBadge(badge, PLACEHOLDER_EARNED.has(badge.id)))}
+        </div>
+      </div>
+    );
+  }
+
+  const ctx = computeContext();
+  const earnedCount = BADGES.filter((b) => b.check(ctx)).length;
+
+  return (
+    <div className="achievements-page">
+      <h2 className="achievements-title">
+        {user.first_name}'s Achievements
+      </h2>
+      <p className="achievements-progress">
+        {earnedCount} / {BADGES.length} earned
+      </p>
+      <div className="badge-grid">
+        {BADGES.map((badge) => renderBadge(badge, badge.check(ctx)))}
+      </div>
+    </div>
+  );
+}

--- a/src/Components/CreateEditHabitModal.jsx
+++ b/src/Components/CreateEditHabitModal.jsx
@@ -3,6 +3,29 @@ import { createPortal } from "react-dom";
 import "../Style/CreateHabitModal.css";
 import CustomRecurrenceModal from "./CustomRecurrenceModal.jsx";
 import * as HabitHelper from "../Helpers/HabitHelper.js";
+import { HABIT_TYPE_LABELS } from "../Helpers/HabitHelper.js";
+
+const TYPE_HINTS = {
+  checkbox: "A simple done / not-done habit.",
+  counter: "Track a daily count against a goal (e.g. glasses of water).",
+  duration: "Track minutes spent against a daily goal.",
+  slider: "Log a numeric value on a custom scale each day.",
+  rating: "Rate your day 1-5 with an emoji scale.",
+  checknote: "Check it off, with an optional note.",
+  shorttext: "A one-line entry each day (e.g. gratitude, highlight).",
+  journal: "A longer freeform journal entry each day.",
+};
+
+const HABIT_TEMPLATES = [
+  { name: "Drink Water", type: "counter", target: "8" },
+  { name: "Exercise", type: "checkbox" },
+  { name: "Read", type: "duration", target: "20" },
+  { name: "Meditate", type: "checkbox" },
+  { name: "Sleep 8h", type: "checkbox" },
+  { name: "Mood Check-in", type: "rating" },
+  { name: "Gratitude", type: "shorttext" },
+  { name: "Journal", type: "journal" },
+];
 
 export default function CreateEditHabitModal({
   user,
@@ -33,6 +56,7 @@ export default function CreateEditHabitModal({
   const [colorLow, setColorLow] = useState("#ff6b6b");
   const [colorMid, setColorMid] = useState("#ffd966");
   const [colorHigh, setColorHigh] = useState("#51cf66");
+  const [archived, setArchived] = useState(false);
 
   useEffect(() => {
     if (!isEditing) setHabitType(defaultHabitType);
@@ -47,6 +71,7 @@ export default function CreateEditHabitModal({
     setHabitType(habitInfo.habitType);
     setHasTags(habitInfo.hasTags);
     setCustomTags(habitInfo.availableTags);
+    setArchived(habitInfo.archived ?? false);
     setInterval(habitInfo.recurrence.interval);
     setRecurrenceDays(habitInfo.recurrence.days);
     if (habitInfo.recurrence.interval === 1) {
@@ -101,12 +126,22 @@ export default function CreateEditHabitModal({
       },
       createdAt: selectedDate,
       target:
-        habitType === "slider" ? parseInt(sliderMax) : parseInt(target) || 1,
+        habitType === "slider"
+          ? parseInt(sliderMax)
+          : habitType === "rating"
+            ? 5
+            : parseInt(target) || 1,
       availableTags: hasTags ? customTags : [],
-      sliderMin: habitType === "slider" ? parseInt(sliderMin) : undefined,
+      sliderMin:
+        habitType === "slider"
+          ? parseInt(sliderMin)
+          : habitType === "rating"
+            ? 1
+            : undefined,
       colorLow: habitType === "slider" ? colorLow : undefined,
       colorMid: habitType === "slider" ? colorMid : undefined,
       colorHigh: habitType === "slider" ? colorHigh : undefined,
+      archived: isEditing ? archived : undefined,
     };
 
     try {
@@ -180,6 +215,56 @@ export default function CreateEditHabitModal({
     }
   };
 
+  const applyTemplate = (template) => {
+    setHabitName(template.name);
+    setHabitType(template.type);
+    setTarget(template.target || "");
+  };
+
+  const handleToggleArchive = async () => {
+    const nextArchived = !archived;
+    const habitData = {
+      userId: user.id,
+      name: habitName.trim(),
+      type: habitType,
+      recurrence: { interval, days: recurrenceDays },
+      target:
+        habitType === "slider"
+          ? parseInt(sliderMax)
+          : habitType === "rating"
+            ? 5
+            : parseInt(target) || 1,
+      availableTags: hasTags ? customTags : [],
+      sliderMin:
+        habitType === "slider"
+          ? parseInt(sliderMin)
+          : habitType === "rating"
+            ? 1
+            : undefined,
+      colorLow: habitType === "slider" ? colorLow : undefined,
+      colorMid: habitType === "slider" ? colorMid : undefined,
+      colorHigh: habitType === "slider" ? colorHigh : undefined,
+      archived: nextArchived,
+    };
+
+    try {
+      const updatedHabit = await onUpdateHabit(habitData, habitId);
+      if (!updatedHabit) return;
+      setArchived(nextArchived);
+      setHabits((prev) =>
+        prev.map((h) =>
+          h.id === habitId
+            ? { ...HabitHelper.mapHabit(updatedHabit), archived: nextArchived }
+            : h,
+        ),
+      );
+      onClose();
+    } catch (err) {
+      console.error("Failed to update archive state:", err);
+      alert("Error: " + err.message);
+    }
+  };
+
   return createPortal(
     <>
       {toggleCustomRecurrence && (
@@ -209,10 +294,11 @@ export default function CreateEditHabitModal({
                 onChange={(e) => setHabitType(e.target.value)}
                 className="type-select"
               >
-                <option value="checkbox">Checkbox</option>
-                <option value="counter">Counter</option>
-                <option value="duration">Duration</option>
-                <option value="slider">Slider</option>
+                {Object.entries(HABIT_TYPE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
               </select>
               <label className="checkbox-label">
                 <input
@@ -226,6 +312,26 @@ export default function CreateEditHabitModal({
             </div>
           </div>
 
+          {!isEditing && (
+            <div className="template-gallery">
+              <p className="form-hint template-gallery-label">
+                Quick add:
+              </p>
+              <div className="template-gallery-items">
+                {HABIT_TEMPLATES.map((template) => (
+                  <button
+                    key={template.name}
+                    type="button"
+                    className="template-chip"
+                    onClick={() => applyTemplate(template)}
+                  >
+                    {template.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           <form onSubmit={handleSubmit} className="habit-form">
             <div className="form-group">
               <label htmlFor="habit-name">Habit Name</label>
@@ -238,6 +344,7 @@ export default function CreateEditHabitModal({
                 className="form-input"
                 autoFocus
               />
+              <p className="form-hint">{TYPE_HINTS[habitType]}</p>
             </div>
 
             {hasTags && (
@@ -503,8 +610,15 @@ export default function CreateEditHabitModal({
                 {isEditing ? "Save Changes" : "Create Habit"}
               </button>
             </div>
-            <div className="modal-actions">
-              {isEditing ? (
+            {isEditing && (
+              <div className="modal-actions">
+                <button
+                  type="button"
+                  onClick={handleToggleArchive}
+                  className="btn-archive"
+                >
+                  {archived ? "Unarchive Habit" : "Archive Habit"}
+                </button>
                 <button
                   type="button"
                   onClick={() => {
@@ -516,10 +630,8 @@ export default function CreateEditHabitModal({
                 >
                   Delete Habit
                 </button>
-              ) : (
-                <></>
-              )}
-            </div>
+              </div>
+            )}
           </form>
         </div>
       </div>

--- a/src/Components/Habit.jsx
+++ b/src/Components/Habit.jsx
@@ -3,12 +3,20 @@ import CheckboxHabit from "./Habits/CheckboxHabit.jsx";
 import CounterHabit from "./Habits/CounterHabit.jsx";
 import DurationHabit from "./Habits/DurationHabit.jsx";
 import SliderHabit from "./Habits/SliderHabit.jsx";
+import RatingHabit from "./Habits/RatingHabit.jsx";
+import CheckNoteHabit from "./Habits/CheckNoteHabit.jsx";
+import ShortTextHabit from "./Habits/ShortTextHabit.jsx";
+import JournalHabit from "./Habits/JournalHabit.jsx";
 
 const HABIT_TYPE_COMPONENTS = {
   checkbox: CheckboxHabit,
   counter: CounterHabit,
   duration: DurationHabit,
   slider: SliderHabit,
+  rating: RatingHabit,
+  checknote: CheckNoteHabit,
+  shorttext: ShortTextHabit,
+  journal: JournalHabit,
 };
 
 export default function Habit({
@@ -30,6 +38,7 @@ export default function Habit({
   onEdit,
   recurrence,
   streak = 0,
+  archived = false,
   ...otherProps
 }) {
   const HabitComponent = HABIT_TYPE_COMPONENTS[type];
@@ -48,9 +57,10 @@ export default function Habit({
 
   return (
     <div
-      className={`habit-row-wrapper${celebrate ? " celebrating" : ""}`}
+      className={`habit-row-wrapper${celebrate ? " celebrating" : ""}${archived ? " habit-row-wrapper--archived" : ""}`}
     >
-      {streak > 0 && (
+      {archived && <span className="archived-tag">Archived</span>}
+      {!archived && streak > 0 && (
         <span className="streak-badge" title={`${streak}-day streak`}>
           🔥 {streak}
         </span>
@@ -72,6 +82,7 @@ export default function Habit({
         colorHigh={colorHigh}
         onEdit={onEdit}
         recurrence={recurrence}
+        archived={archived}
         {...otherProps}
       />
       {celebrate && (

--- a/src/Components/Habits/CheckNoteHabit.jsx
+++ b/src/Components/Habits/CheckNoteHabit.jsx
@@ -1,0 +1,69 @@
+import "../../Style/HabitTypes.css";
+
+export default function CheckNoteHabit({
+  id,
+  name,
+  completed,
+  onToggle,
+  textValue = "",
+  onTextChange,
+  hasTags,
+  tag,
+  availableTags,
+  onTagChange,
+  onEdit,
+  recurrence,
+  archived,
+}) {
+  const habitInfo = {
+    id,
+    name,
+    habitType: "checknote",
+    hasTags,
+    availableTags,
+    recurrence,
+    archived,
+  };
+
+  return (
+    <div className="habit-container habit-container--stacked">
+      <div className="habit-container-row">
+        <span className="habit-name">{name}</span>
+        <div className="habit-controls">
+          <button className="btn-edit" onClick={() => onEdit(habitInfo)}>
+            Edit
+          </button>
+          {hasTags && availableTags && availableTags.length > 0 && (
+            <select
+              value={tag || ""}
+              onChange={(e) => onTagChange(e.target.value)}
+              className="habit-tag-select"
+            >
+              <option value="">Select tag...</option>
+              {availableTags.map((availableTag) => (
+                <option key={availableTag} value={availableTag}>
+                  {availableTag}
+                </option>
+              ))}
+            </select>
+          )}
+          <input
+            type="checkbox"
+            checked={completed}
+            onChange={onToggle}
+            className="habit-checkbox"
+          />
+        </div>
+      </div>
+      {completed && (
+        <input
+          type="text"
+          value={textValue}
+          onChange={(e) => onTextChange(e.target.value)}
+          placeholder="Add a note (optional)..."
+          className="habit-note-input"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/Components/Habits/JournalHabit.jsx
+++ b/src/Components/Habits/JournalHabit.jsx
@@ -1,0 +1,59 @@
+import "../../Style/HabitTypes.css";
+
+export default function JournalHabit({
+  id,
+  name,
+  textValue = "",
+  onTextChange,
+  hasTags,
+  tag,
+  availableTags,
+  onTagChange,
+  onEdit,
+  recurrence,
+  archived,
+}) {
+  const habitInfo = {
+    id,
+    name,
+    habitType: "journal",
+    hasTags,
+    availableTags,
+    recurrence,
+    archived,
+  };
+
+  return (
+    <div className="habit-container habit-container--stacked">
+      <div className="habit-container-row">
+        <span className="habit-name">{name}</span>
+        <div className="habit-controls">
+          <button className="btn-edit" onClick={() => onEdit(habitInfo)}>
+            Edit
+          </button>
+          {hasTags && availableTags && availableTags.length > 0 && (
+            <select
+              value={tag || ""}
+              onChange={(e) => onTagChange(e.target.value)}
+              className="habit-tag-select"
+            >
+              <option value="">Select tag...</option>
+              {availableTags.map((availableTag) => (
+                <option key={availableTag} value={availableTag}>
+                  {availableTag}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      </div>
+      <textarea
+        value={textValue}
+        onChange={(e) => onTextChange(e.target.value)}
+        placeholder="Write today's journal entry..."
+        className="habit-journal-textarea"
+        rows={4}
+      />
+    </div>
+  );
+}

--- a/src/Components/Habits/RatingHabit.jsx
+++ b/src/Components/Habits/RatingHabit.jsx
@@ -1,0 +1,69 @@
+import "../../Style/HabitTypes.css";
+
+const FACES = ["😞", "🙁", "😐", "🙂", "😄"];
+
+export default function RatingHabit({
+  id,
+  name,
+  value = 3,
+  hasTags,
+  tag,
+  availableTags,
+  onValueChange,
+  onTagChange,
+  onEdit,
+  recurrence,
+  archived,
+}) {
+  const habitInfo = {
+    id,
+    name,
+    habitType: "rating",
+    target: 5,
+    hasTags,
+    availableTags,
+    recurrence,
+    archived,
+  };
+
+  return (
+    <div className="habit-container">
+      <span className="habit-name">{name}</span>
+      <div className="habit-controls">
+        <button className="btn-edit" onClick={() => onEdit(habitInfo)}>
+          Edit
+        </button>
+        {hasTags && availableTags && availableTags.length > 0 && (
+          <select
+            value={tag || ""}
+            onChange={(e) => onTagChange(e.target.value)}
+            className="habit-tag-select"
+          >
+            <option value="">Select tag...</option>
+            {availableTags.map((availableTag) => (
+              <option key={availableTag} value={availableTag}>
+                {availableTag}
+              </option>
+            ))}
+          </select>
+        )}
+        <div className="rating-faces">
+          {FACES.map((face, i) => {
+            const faceValue = i + 1;
+            return (
+              <button
+                key={faceValue}
+                type="button"
+                className={`rating-face-btn${value === faceValue ? " selected" : ""}`}
+                onClick={() => onValueChange(faceValue)}
+                title={`${faceValue} / 5`}
+              >
+                {face}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/Components/Habits/ShortTextHabit.jsx
+++ b/src/Components/Habits/ShortTextHabit.jsx
@@ -1,0 +1,59 @@
+import "../../Style/HabitTypes.css";
+
+export default function ShortTextHabit({
+  id,
+  name,
+  textValue = "",
+  onTextChange,
+  hasTags,
+  tag,
+  availableTags,
+  onTagChange,
+  onEdit,
+  recurrence,
+  archived,
+}) {
+  const habitInfo = {
+    id,
+    name,
+    habitType: "shorttext",
+    hasTags,
+    availableTags,
+    recurrence,
+    archived,
+  };
+
+  return (
+    <div className="habit-container habit-container--stacked">
+      <div className="habit-container-row">
+        <span className="habit-name">{name}</span>
+        <div className="habit-controls">
+          <button className="btn-edit" onClick={() => onEdit(habitInfo)}>
+            Edit
+          </button>
+          {hasTags && availableTags && availableTags.length > 0 && (
+            <select
+              value={tag || ""}
+              onChange={(e) => onTagChange(e.target.value)}
+              className="habit-tag-select"
+            >
+              <option value="">Select tag...</option>
+              {availableTags.map((availableTag) => (
+                <option key={availableTag} value={availableTag}>
+                  {availableTag}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      </div>
+      <input
+        type="text"
+        value={textValue}
+        onChange={(e) => onTextChange(e.target.value)}
+        placeholder="Write today's entry..."
+        className="habit-note-input"
+      />
+    </div>
+  );
+}

--- a/src/Components/HabitsPage.jsx
+++ b/src/Components/HabitsPage.jsx
@@ -5,6 +5,7 @@ import "../Style/HabitsPage.css";
 import Calendar from "./Calendar.jsx";
 import * as CompletionHelper from "../Helpers/CompletionHelper.js";
 import * as HabitHelper from "../Helpers/HabitHelper.js";
+import { HABIT_TYPE_LABELS } from "../Helpers/HabitHelper.js";
 import { findStreaks, formatDate } from "../Helpers/StreakHelper.js";
 
 export default function HabitsPage({
@@ -124,6 +125,7 @@ export default function HabitsPage({
           update.date,
           update.selectedTag || null,
           update.value || null,
+          update.textValue,
         );
       } else if (update.action === "delete") {
         await CompletionHelper.deleteCompletionByHabitAndDate(
@@ -155,6 +157,9 @@ export default function HabitsPage({
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [showArchived, setShowArchived] = useState(false);
 
   const toggleHabit = async (id) => {
     const habit = habits.find((h) => h.id === id);
@@ -169,6 +174,7 @@ export default function HabitsPage({
           action: "create",
           selectedTag: habit.selectedTag || null,
           value: habit.value || null,
+          textValue: habit.textValue || undefined,
           date: dateAtToggle,
         },
       }));
@@ -190,6 +196,57 @@ export default function HabitsPage({
   const updateHabitTag = (id, newTag) => {
     setHabits((prev) =>
       prev.map((h) => (h.id === id ? { ...h, selectedTag: newTag } : h)),
+    );
+  };
+
+  // shorttext / journal: typing saves the entry, clearing it removes it.
+  const updateHabitTextValue = (id, newText) => {
+    const habit = habits.find((h) => h.id === id);
+    if (!habit || !user) return;
+
+    const dateAtChange = new Date(selectedDate);
+    const isEmpty = newText.trim() === "";
+
+    setPendingCompletions((prev) => ({
+      ...prev,
+      [habit.id]: isEmpty
+        ? { action: "delete", date: dateAtChange }
+        : {
+            action: "create",
+            selectedTag: habit.selectedTag || null,
+            value: null,
+            textValue: newText,
+            date: dateAtChange,
+          },
+    }));
+
+    setHabits((prev) =>
+      prev.map((h) =>
+        h.id === id ? { ...h, textValue: newText, completed: !isEmpty } : h,
+      ),
+    );
+  };
+
+  // checknote: the note only exists while the checkbox is already checked.
+  const updateHabitNote = (id, newText) => {
+    const habit = habits.find((h) => h.id === id);
+    if (!habit || !user || !habit.completed) return;
+
+    const dateAtChange = new Date(selectedDate);
+
+    setPendingCompletions((prev) => ({
+      ...prev,
+      [habit.id]: {
+        action: "create",
+        selectedTag: habit.selectedTag || null,
+        value: null,
+        textValue: newText,
+        date: dateAtChange,
+      },
+    }));
+
+    setHabits((prev) =>
+      prev.map((h) => (h.id === id ? { ...h, textValue: newText } : h)),
     );
   };
 
@@ -223,18 +280,21 @@ export default function HabitsPage({
           if (completion) {
             let isCompleted = false;
 
-            if (habit.type === "checkbox") {
+            if (habit.type === "checkbox" || habit.type === "checknote") {
               isCompleted = true;
             } else if (habit.type === "counter" || habit.type === "duration") {
               isCompleted = (completion.value ?? 0) >= habit.target;
-            } else if (habit.type === "slider") {
+            } else if (habit.type === "slider" || habit.type === "rating") {
               isCompleted = completion.value != null;
+            } else if (habit.type === "shorttext" || habit.type === "journal") {
+              isCompleted = (completion.text_value ?? "").trim() !== "";
             }
 
             return {
               ...habit,
               completed: isCompleted,
               value: Number(completion.value),
+              textValue: completion.text_value ?? "",
               selectedTag: completion.selected_tag,
             };
           }
@@ -242,6 +302,7 @@ export default function HabitsPage({
             ...habit,
             completed: false,
             value: habit.defaultValue,
+            textValue: "",
             selectedTag: null,
           };
         });
@@ -302,6 +363,20 @@ export default function HabitsPage({
     setIsModalOpen(true);
   };
 
+  const visibleHabits = habits
+    .filter((habit) => showArchived || !habit.archived)
+    .filter(
+      (habit) => habit.archived || isHabitScheduledForDate(habit, selectedDate),
+    )
+    .filter((habit) =>
+      searchQuery.trim()
+        ? habit.name.toLowerCase().includes(searchQuery.trim().toLowerCase())
+        : true,
+    )
+    .filter((habit) => (typeFilter === "all" ? true : habit.type === typeFilter));
+
+  const habitTypesPresent = Array.from(new Set(habits.map((h) => h.type)));
+
   return (
     <div className="daily-page">
       <div className="page-header">
@@ -351,14 +426,46 @@ export default function HabitsPage({
           />
         )}
       </div>
+      {user && habits.length > 0 && (
+        <div className="habit-filter-bar">
+          <input
+            type="text"
+            className="habit-filter-search"
+            placeholder="Search habits..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          <select
+            className="habit-filter-type"
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+          >
+            <option value="all">All types</option>
+            {habitTypesPresent.map((t) => (
+              <option key={t} value={t}>
+                {HABIT_TYPE_LABELS[t] || t}
+              </option>
+            ))}
+          </select>
+          <label className="habit-filter-archived">
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={(e) => setShowArchived(e.target.checked)}
+            />
+            Show archived
+          </label>
+        </div>
+      )}
       <div className="daily-habits-list">
-        {habits.filter((habit) => isHabitScheduledForDate(habit, selectedDate))
-          .length === 0 && (
-          <p className="daily-empty">No habits scheduled for this day.</p>
+        {visibleHabits.length === 0 && (
+          <p className="daily-empty">
+            {habits.length === 0
+              ? "No habits yet — create your first one!"
+              : "No habits match this day/filter."}
+          </p>
         )}
-        {habits
-          .filter((habit) => isHabitScheduledForDate(habit, selectedDate))
-          .map((habit) => {
+        {visibleHabits.map((habit) => {
             return (
               <Habit
                 key={habit.id}
@@ -373,10 +480,17 @@ export default function HabitsPage({
                 target={habit.target || 1}
                 recurrence={habit.recurrence}
                 streak={getStreakForHabit(habit)}
+                archived={habit.archived}
+                textValue={habit.textValue || ""}
                 onToggle={() => toggleHabit(habit.id)}
                 onTagChange={(newTag) => updateHabitTag(habit.id, newTag)}
                 onValueChange={(newValue) =>
                   updateHabitValue(habit.id, newValue)
+                }
+                onTextChange={(newText) =>
+                  habit.type === "checknote"
+                    ? updateHabitNote(habit.id, newText)
+                    : updateHabitTextValue(habit.id, newText)
                 }
                 sliderMin={habit.sliderMin}
                 colorLow={habit.colorLow}

--- a/src/Components/History.jsx
+++ b/src/Components/History.jsx
@@ -1,0 +1,152 @@
+import { useState, useEffect, useMemo } from "react";
+import * as HabitHelper from "../Helpers/HabitHelper.js";
+import * as CompletionHelper from "../Helpers/CompletionHelper.js";
+import { formatDate } from "../Helpers/StreakHelper.js";
+import "../Style/History.css";
+
+const WEEKS_SHOWN = 18;
+const DAY_LABELS = ["S", "M", "T", "W", "T", "F", "S"];
+
+function buildWeeks(today) {
+  const end = new Date(today);
+  end.setDate(end.getDate() + (6 - end.getDay()));
+  const weeks = [];
+  for (let w = WEEKS_SHOWN - 1; w >= 0; w--) {
+    const week = [];
+    for (let d = 0; d < 7; d++) {
+      const date = new Date(end);
+      date.setDate(date.getDate() - w * 7 - (6 - d));
+      week.push(date);
+    }
+    weeks.push(week);
+  }
+  return weeks;
+}
+
+export default function History({ user }) {
+  const [habits, setHabits] = useState([]);
+  const [completions, setCompletions] = useState([]);
+  const [selectedHabitId, setSelectedHabitId] = useState(null);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  useEffect(() => {
+    if (!user) return;
+    const load = async () => {
+      const [rawHabits, allCompletions] = await Promise.all([
+        HabitHelper.getHabitsByUserId(user.id),
+        CompletionHelper.getCompletionsByUserId(user.id),
+      ]);
+      const mapped = rawHabits.map(HabitHelper.mapHabit);
+      setHabits(mapped);
+      setCompletions(allCompletions);
+      if (mapped.length > 0) setSelectedHabitId(mapped[0].id);
+    };
+    load();
+  }, [user?.id]);
+
+  const weeks = buildWeeks(today);
+
+  const habit = habits.find((h) => h.id === selectedHabitId);
+
+  const completionByDate = useMemo(() => {
+    if (!habit) return new Map();
+    const map = new Map();
+    completions
+      .filter((c) => c.habit_id === habit.id)
+      .forEach((c) => map.set(c.date, c));
+    return map;
+  }, [habit, completions]);
+
+  const getLevel = (date) => {
+    if (!habit) return -1;
+    const habitStart = new Date(habit.createdAt);
+    habitStart.setHours(0, 0, 0, 0);
+    if (date < habitStart || date > today) return -1;
+    if (!habit.recurrence.days.includes(date.getDay())) return -1;
+
+    const completion = completionByDate.get(formatDate(date));
+    if (!completion) return 0;
+
+    if (habit.type === "counter" || habit.type === "duration") {
+      const ratio = habit.target ? (completion.value ?? 0) / habit.target : 1;
+      if (ratio >= 1) return 4;
+      if (ratio >= 0.66) return 3;
+      if (ratio >= 0.33) return 2;
+      return 1;
+    }
+    if (habit.type === "slider" || habit.type === "rating") {
+      return completion.value != null ? 4 : 0;
+    }
+    if (habit.type === "shorttext" || habit.type === "journal") {
+      return (completion.text_value ?? "").trim() !== "" ? 4 : 0;
+    }
+    return 4; // checkbox / checknote: binary
+  };
+
+  if (!user) {
+    return (
+      <div className="history-page">
+        <h2 className="history-title">History</h2>
+        <p className="history-no-user">Log in to see your habit history.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="history-page">
+      <h2 className="history-title">History</h2>
+      {habits.length === 0 ? (
+        <p className="history-empty">No habits yet.</p>
+      ) : (
+        <>
+          <select
+            className="history-habit-select"
+            value={selectedHabitId || ""}
+            onChange={(e) => setSelectedHabitId(e.target.value)}
+          >
+            {habits.map((h) => (
+              <option key={h.id} value={h.id}>
+                {h.name}
+              </option>
+            ))}
+          </select>
+          <div className="history-heatmap-scroll">
+            <div className="history-heatmap">
+              <div className="history-day-labels">
+                {DAY_LABELS.map((label, i) => (
+                  <span key={i} className="history-day-label">
+                    {label}
+                  </span>
+                ))}
+              </div>
+              {weeks.map((week, wi) => (
+                <div key={wi} className="history-week-column">
+                  {week.map((date, di) => {
+                    const level = getLevel(date);
+                    return (
+                      <div
+                        key={di}
+                        className={`history-cell history-cell--${level}`}
+                        title={`${date.toLocaleDateString()}${level >= 0 ? (level > 0 ? " — done" : " — missed") : ""}`}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="history-legend">
+            <span>Less</span>
+            <span className="history-cell history-cell--0" />
+            <span className="history-cell history-cell--1" />
+            <span className="history-cell history-cell--2" />
+            <span className="history-cell history-cell--3" />
+            <span className="history-cell history-cell--4" />
+            <span>More</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/Components/Navbar.jsx
+++ b/src/Components/Navbar.jsx
@@ -9,7 +9,7 @@ export default function NavBar({
   user,
 }) {
   const leftTabs = ["Habits"];
-  const rightTabs = ["Stats", "Glance"];
+  const rightTabs = ["Stats", "Glance", "History", "Achievements"];
 
   return (
     <div className="navbar">

--- a/src/Components/Settings.jsx
+++ b/src/Components/Settings.jsx
@@ -1,8 +1,49 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import DeleteAccountModal from "./DeleteAccountModal.jsx";
 import * as UserHelper from "../Helpers/UserHelper.js";
 import * as SettingsHelper from "../Helpers/SettingsHelper.js";
+import * as HabitHelper from "../Helpers/HabitHelper.js";
+import { HABIT_TYPE_LABELS } from "../Helpers/HabitHelper.js";
+import * as CompletionHelper from "../Helpers/CompletionHelper.js";
+import * as ReminderHelper from "../Helpers/ReminderHelper.js";
 import "../Style/Settings.css";
+
+function toCSV(habits, completions) {
+  const header = [
+    "habit_name",
+    "habit_type",
+    "date",
+    "value",
+    "text_value",
+    "selected_tag",
+  ];
+  const rows = completions.map((c) => {
+    const habit = habits.find((h) => h.id === c.habit_id);
+    return [
+      habit ? habit.name : c.habit_id,
+      habit ? habit.type : "",
+      c.date,
+      c.value ?? "",
+      c.text_value ?? "",
+      c.selected_tag ?? "",
+    ]
+      .map((field) => `"${String(field).replaceAll('"', '""')}"`)
+      .join(",");
+  });
+  return [header.join(","), ...rows].join("\n");
+}
+
+function downloadFile(filename, content, mimeType) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
 
 export default function Settings({
   user,
@@ -21,6 +62,57 @@ export default function Settings({
   setDefaultHabitType,
 }) {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [reminderEnabled, setReminderEnabled] = useState(false);
+  const [reminderTime, setReminderTime] = useState("18:00");
+  const [notifPermission, setNotifPermission] = useState(
+    typeof Notification !== "undefined" ? Notification.permission : "unsupported",
+  );
+
+  useEffect(() => {
+    if (!user) return;
+    const settings = ReminderHelper.getReminderSettings(user.id);
+    setReminderEnabled(settings.enabled);
+    setReminderTime(settings.time);
+  }, [user?.id]);
+
+  const saveReminderSettings = (next) => {
+    ReminderHelper.setReminderSettings(user.id, next);
+  };
+
+  const requestNotificationPermission = async () => {
+    if (typeof Notification === "undefined") return;
+    const permission = await Notification.requestPermission();
+    setNotifPermission(permission);
+  };
+
+  const handleExport = async (format) => {
+    if (!user) return;
+    setIsExporting(true);
+    try {
+      const [rawHabits, completions] = await Promise.all([
+        HabitHelper.getHabitsByUserId(user.id),
+        CompletionHelper.getCompletionsByUserId(user.id),
+      ]);
+      const habits = rawHabits.map(HabitHelper.mapHabit);
+
+      if (format === "json") {
+        downloadFile(
+          `habit-tracker-export-${user.username}.json`,
+          JSON.stringify({ habits, completions }, null, 2),
+          "application/json",
+        );
+      } else {
+        downloadFile(
+          `habit-tracker-export-${user.username}.csv`,
+          toCSV(habits, completions),
+          "text/csv",
+        );
+      }
+    } finally {
+      setIsExporting(false);
+    }
+  };
 
   return (
     <div className="settings-div">
@@ -61,6 +153,8 @@ export default function Settings({
             <option value="profile">Profile</option>
             <option value="glance">At A Glance</option>
             <option value="stats">Stats</option>
+            <option value="history">History</option>
+            <option value="achievements">Achievements</option>
           </select>
         </div>
       </div>
@@ -72,11 +166,84 @@ export default function Settings({
           value={defaultHabitType}
           onChange={(e) => setDefaultHabitType(e.target.value)}
         >
-          <option value="checkbox">Checkbox</option>
-          <option value="counter">Counter</option>
-          <option value="duration">Duration</option>
-          <option value="slider">Slider</option>
+          {Object.entries(HABIT_TYPE_LABELS).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
         </select>
+      </div>
+
+      <div className="settings-section">
+        <p className="settings-label">Reminders</p>
+        {notifPermission !== "granted" ? (
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={requestNotificationPermission}
+          >
+            Enable browser notifications
+          </button>
+        ) : (
+          <>
+            <label className="settings-row settings-checkbox-row">
+              <input
+                type="checkbox"
+                checked={reminderEnabled}
+                onChange={(e) => {
+                  setReminderEnabled(e.target.checked);
+                  saveReminderSettings({
+                    enabled: e.target.checked,
+                    time: reminderTime,
+                  });
+                }}
+              />
+              Remind me about incomplete habits
+            </label>
+            {reminderEnabled && (
+              <div className="settings-row">
+                <p className="settings-sublabel">At</p>
+                <input
+                  type="time"
+                  className="settings-select"
+                  value={reminderTime}
+                  onChange={(e) => {
+                    setReminderTime(e.target.value);
+                    saveReminderSettings({
+                      enabled: reminderEnabled,
+                      time: e.target.value,
+                    });
+                  }}
+                />
+              </div>
+            )}
+            <p className="settings-hint">
+              Only fires while this app is open in a browser tab.
+            </p>
+          </>
+        )}
+      </div>
+
+      <div className="settings-section">
+        <p className="settings-label">Export Your Data</p>
+        <div className="settings-row">
+          <button
+            type="button"
+            className="btn-secondary"
+            disabled={isExporting}
+            onClick={() => handleExport("json")}
+          >
+            Download JSON
+          </button>
+          <button
+            type="button"
+            className="btn-secondary"
+            disabled={isExporting}
+            onClick={() => handleExport("csv")}
+          >
+            Download CSV
+          </button>
+        </div>
       </div>
 
       <div className="settings-account">

--- a/src/Helpers/CompletionHelper.js
+++ b/src/Helpers/CompletionHelper.js
@@ -13,6 +13,7 @@ export async function createCompletion(
   date,
   selectedTag,
   value,
+  textValue,
 ) {
   try {
     const res = await fetch(`${backend_base_url}/completions`, {
@@ -24,6 +25,7 @@ export async function createCompletion(
         date: formatDate(date),
         selectedTag,
         value,
+        textValue,
       }),
     });
 

--- a/src/Helpers/HabitHelper.js
+++ b/src/Helpers/HabitHelper.js
@@ -1,10 +1,23 @@
 const backend_base_url = import.meta.env.VITE_BACKEND_BASE_URL;
 
+export const HABIT_TYPE_LABELS = {
+  checkbox: "Checkbox",
+  counter: "Counter",
+  duration: "Duration",
+  slider: "Slider",
+  rating: "Rating",
+  checknote: "Yes/No + Note",
+  shorttext: "Short Text",
+  journal: "Journal",
+};
+
 export function mapHabit(habit) {
     const defaultVal =
       habit.type === "slider"
         ? Math.floor(((Number(habit.slider_min) || 1) + (Number(habit.target) || 10)) / 2)
-        : 0;
+        : habit.type === "rating"
+          ? 3
+          : 0;
 
     return {
       id: habit.habit_id,
@@ -18,6 +31,7 @@ export function mapHabit(habit) {
       },
       value: Number(defaultVal),
       defaultValue: defaultVal,
+      textValue: "",
       hasTags: (habit.available_tags ?? []).length > 0,
       availableTags: habit.available_tags ?? [],
       selectedTag: null,
@@ -26,6 +40,7 @@ export function mapHabit(habit) {
       colorLow: habit.color_low,
       colorMid: habit.color_mid,
       colorHigh: habit.color_high,
+      archived: habit.archived ?? false,
     };
   };
 
@@ -106,6 +121,7 @@ export async function onUpdateHabit(habit, habitId) {
         colorMid: habit.colorMid,
         colorHigh: habit.colorHigh,
         recurrence: habit.recurrence,
+        archived: habit.archived,
       }),
     });
 

--- a/src/Helpers/ReminderHelper.js
+++ b/src/Helpers/ReminderHelper.js
@@ -1,0 +1,57 @@
+export function getReminderSettings(userId) {
+  try {
+    const raw = localStorage.getItem(`reminders_${userId}`);
+    if (!raw) return { enabled: false, time: "18:00" };
+    return JSON.parse(raw);
+  } catch {
+    return { enabled: false, time: "18:00" };
+  }
+}
+
+export function setReminderSettings(userId, settings) {
+  localStorage.setItem(`reminders_${userId}`, JSON.stringify(settings));
+}
+
+function todayKey() {
+  const d = new Date();
+  return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+}
+
+function alreadyNotifiedToday(userId) {
+  return localStorage.getItem(`reminded_${userId}`) === todayKey();
+}
+
+function markNotifiedToday(userId) {
+  localStorage.setItem(`reminded_${userId}`, todayKey());
+}
+
+// Checks whether it's time to remind the user, and fires a browser
+// notification listing incomplete habits scheduled for today. Intended to
+// be called on an interval while the app is open (no service worker/push,
+// so it only works while a tab is open).
+export function maybeNotify(userId, incompleteHabitNames) {
+  if (typeof Notification === "undefined") return;
+  if (Notification.permission !== "granted") return;
+
+  const { enabled, time } = getReminderSettings(userId);
+  if (!enabled) return;
+  if (alreadyNotifiedToday(userId)) return;
+
+  const now = new Date();
+  const [hh, mm] = (time || "18:00").split(":").map(Number);
+  const target = new Date(now);
+  target.setHours(hh, mm, 0, 0);
+
+  if (now < target) return;
+  if (incompleteHabitNames.length === 0) return;
+
+  const body =
+    incompleteHabitNames.length <= 3
+      ? incompleteHabitNames.join(", ")
+      : `${incompleteHabitNames.slice(0, 3).join(", ")} + ${incompleteHabitNames.length - 3} more`;
+
+  new Notification("Habit Tracker reminder", {
+    body: `Still to do today: ${body}`,
+  });
+  markNotifiedToday(userId);
+}

--- a/src/Style/Achievements.css
+++ b/src/Style/Achievements.css
@@ -1,0 +1,71 @@
+.achievements-page {
+  display: flex;
+  flex-direction: column;
+}
+
+.achievements-title {
+  color: var(--ink);
+  font-family: var(--font-hand);
+  font-size: 32px;
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+
+.achievements-progress {
+  color: var(--ink-soft);
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 18px;
+}
+
+.achievements-no-user {
+  color: var(--ink-faint);
+  font-style: italic;
+  font-size: 14px;
+  margin: 0 0 18px;
+}
+
+.badge-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.badge-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 6px;
+  padding: 16px 10px;
+  border-radius: 10px;
+  border: 1.5px solid var(--card-border);
+  background: var(--card-bg);
+  transition: all 0.2s ease;
+}
+
+.badge-tile--earned {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-soft);
+}
+
+.badge-tile--locked {
+  opacity: 0.5;
+}
+
+.badge-icon {
+  font-size: 28px;
+  line-height: 1;
+}
+
+.badge-label {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.badge-description {
+  font-size: 11px;
+  color: var(--ink-faint);
+  line-height: 1.4;
+}

--- a/src/Style/AtAGlance.css
+++ b/src/Style/AtAGlance.css
@@ -78,8 +78,9 @@
 }
 
 .glance-habit-row:hover {
-  border-color: var(--card-border-hover);
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+  background: var(--card-bg-hover);
+  border-color: var(--accent);
+  box-shadow: var(--elevated-shadow-hover);
 }
 
 .glance-habit-name {

--- a/src/Style/CreateHabitModal.css
+++ b/src/Style/CreateHabitModal.css
@@ -362,6 +362,59 @@
   font-family: inherit;
 }
 
+.btn-archive {
+  flex: 1;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1.5px solid var(--card-border-hover);
+  background-color: transparent;
+  color: var(--ink);
+  font-family: inherit;
+}
+
+.btn-archive:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.template-gallery {
+  margin: -8px 0 20px;
+  padding-top: 4px;
+  border-top: 1px dashed var(--card-border);
+}
+
+.template-gallery-label {
+  margin: 10px 0 8px;
+}
+
+.template-gallery-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.template-chip {
+  padding: 6px 14px;
+  border: 1.5px solid var(--input-border);
+  border-radius: 20px;
+  background: var(--input-bg);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: inherit;
+}
+
+.template-chip:hover {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
 .btn-delete:hover {
   background-color: var(--danger);
   color: #fff;

--- a/src/Style/HabitTypes.css
+++ b/src/Style/HabitTypes.css
@@ -26,6 +26,91 @@
   box-shadow: 0 0 0 3px var(--success-soft);
 }
 
+.habit-container--stacked {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.habit-container-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.habit-note-input,
+.habit-journal-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 12px;
+  border: 1.5px solid var(--input-border);
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+  background: var(--input-bg);
+  color: var(--ink);
+  transition: border-color 0.2s ease;
+}
+
+.habit-note-input:focus,
+.habit-journal-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.habit-journal-textarea {
+  resize: vertical;
+  min-height: 70px;
+}
+
+.rating-faces {
+  display: flex;
+  gap: 4px;
+}
+
+.rating-face-btn {
+  background: none;
+  border: 1.5px solid transparent;
+  border-radius: 8px;
+  font-size: 20px;
+  padding: 2px 5px;
+  cursor: pointer;
+  opacity: 0.4;
+  transition: all 0.15s ease;
+  line-height: 1;
+}
+
+.rating-face-btn:hover {
+  opacity: 0.8;
+}
+
+.rating-face-btn.selected {
+  opacity: 1;
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.habit-row-wrapper--archived .habit-container {
+  opacity: 0.55;
+}
+
+.archived-tag {
+  position: absolute;
+  top: -10px;
+  right: 14px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--card-bg);
+  border: 1.5px solid var(--card-border);
+  padding: 2px 8px;
+  border-radius: 999px;
+  z-index: 2;
+}
+
 .habit-name {
   font-weight: 600;
   font-size: 16px;

--- a/src/Style/HabitTypes.css
+++ b/src/Style/HabitTypes.css
@@ -16,8 +16,9 @@
 }
 
 .habit-container:hover {
-  border-color: var(--card-border-hover);
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+  background: var(--card-bg-hover);
+  border-color: var(--accent);
+  box-shadow: var(--elevated-shadow-hover);
   transform: translateY(-1px);
 }
 

--- a/src/Style/HabitsPage.css
+++ b/src/Style/HabitsPage.css
@@ -86,6 +86,53 @@
   z-index: 99;
 }
 
+.habit-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+.habit-filter-search {
+  flex: 1;
+  min-width: 140px;
+  padding: 8px 12px;
+  border: 1.5px solid var(--input-border);
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--input-bg);
+  color: var(--ink);
+  transition: border-color 0.2s ease;
+}
+
+.habit-filter-search:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.habit-filter-type {
+  padding: 8px 10px;
+  border: 1.5px solid var(--input-border);
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--input-bg);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.habit-filter-archived {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--ink-soft);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
 .daily-habits-list {
   display: flex;
   flex-direction: column;

--- a/src/Style/History.css
+++ b/src/Style/History.css
@@ -1,0 +1,102 @@
+.history-page {
+  display: flex;
+  flex-direction: column;
+}
+
+.history-title {
+  color: var(--ink);
+  font-family: var(--font-hand);
+  font-size: 32px;
+  font-weight: 700;
+  margin: 0 0 18px;
+}
+
+.history-no-user,
+.history-empty {
+  color: var(--ink-faint);
+  font-style: italic;
+  font-size: 14px;
+}
+
+.history-habit-select {
+  padding: 8px 12px;
+  border: 1.5px solid var(--input-border);
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  background: var(--input-bg);
+  color: var(--ink);
+  cursor: pointer;
+  margin-bottom: 18px;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.history-heatmap-scroll {
+  overflow-x: auto;
+  padding-bottom: 6px;
+}
+
+.history-heatmap {
+  display: flex;
+  gap: 3px;
+  width: fit-content;
+}
+
+.history-day-labels {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-right: 4px;
+}
+
+.history-day-label {
+  height: 12px;
+  width: 14px;
+  font-size: 9px;
+  color: var(--ink-faint);
+  display: flex;
+  align-items: center;
+}
+
+.history-week-column {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.history-cell {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: var(--card-border);
+}
+
+.history-cell--0 {
+  background: var(--card-border);
+}
+
+.history-cell--1 {
+  background: var(--accent-soft);
+}
+
+.history-cell--2 {
+  background: color-mix(in srgb, var(--accent) 45%, var(--card-bg));
+}
+
+.history-cell--3 {
+  background: color-mix(in srgb, var(--accent) 70%, var(--card-bg));
+}
+
+.history-cell--4 {
+  background: var(--accent);
+}
+
+.history-legend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 14px;
+  font-size: 11px;
+  color: var(--ink-faint);
+}

--- a/src/Style/Navbar.css
+++ b/src/Style/Navbar.css
@@ -34,9 +34,9 @@
 
 .nav-tab {
   padding: 7px 16px;
-  background: rgba(255, 253, 246, 0.92);
+  background: var(--card-bg);
   color: var(--ink);
-  border: none;
+  border: 1.5px solid var(--card-border);
   border-radius: 8px;
   font-size: 13px;
   font-weight: 700;
@@ -47,7 +47,7 @@
 }
 
 .nav-tab:hover {
-  background: #fff;
+  border-color: var(--accent);
   transform: translateY(-1px);
 }
 

--- a/src/Style/Settings.css
+++ b/src/Style/Settings.css
@@ -107,3 +107,39 @@
   background: var(--danger);
   color: #fff;
 }
+
+.settings-checkbox-row {
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--ink);
+}
+
+.settings-hint {
+  font-size: 12px;
+  color: var(--ink-faint);
+  font-style: italic;
+  margin: 0;
+}
+
+.btn-secondary {
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1.5px solid var(--input-border);
+  background: var(--input-bg);
+  color: var(--ink);
+  font-family: inherit;
+}
+
+.btn-secondary:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.btn-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/Style/Stats.css
+++ b/src/Style/Stats.css
@@ -71,8 +71,9 @@
 }
 
 .stats-habit-card:hover {
-  border-color: var(--card-border-hover);
-  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.08);
+  background: var(--card-bg-hover);
+  border-color: var(--accent);
+  box-shadow: var(--elevated-shadow-hover);
 }
 
 .stats-habit-name {

--- a/src/index.css
+++ b/src/index.css
@@ -33,10 +33,13 @@
 
   /* Surfaces */
   --card-bg: #fffaf0;
+  --card-bg-hover: #fffef8;
   --card-border: rgba(90, 70, 40, 0.16);
   --card-border-hover: rgba(90, 70, 40, 0.32);
   --input-bg: #ffffff;
   --input-border: rgba(90, 70, 40, 0.22);
+  --elevated-shadow: 0 3px 10px rgba(60, 40, 10, 0.1);
+  --elevated-shadow-hover: 0 6px 18px rgba(60, 40, 10, 0.14);
 
   /* Status */
   --success: #3f9a5c;
@@ -82,11 +85,16 @@
   --accent-2: #7fa6e0;
   --accent-2-soft: rgba(127, 166, 224, 0.14);
 
-  --card-bg: #262332;
-  --card-border: rgba(238, 230, 216, 0.1);
-  --card-border-hover: rgba(238, 230, 216, 0.22);
+  --card-bg: #2a2738;
+  --card-bg-hover: #302c40;
+  --card-border: rgba(238, 230, 216, 0.16);
+  --card-border-hover: rgba(238, 230, 216, 0.34);
   --input-bg: #201d29;
-  --input-border: rgba(238, 230, 216, 0.16);
+  --input-border: rgba(238, 230, 216, 0.2);
+  --elevated-shadow: 0 3px 12px rgba(0, 0, 0, 0.4);
+  --elevated-shadow-hover:
+    0 8px 22px rgba(0, 0, 0, 0.5),
+    0 0 0 1px var(--accent-soft);
 
   --success: #6fce8c;
   --success-soft: rgba(111, 206, 140, 0.14);


### PR DESCRIPTION
## Summary
- **4 new habit types**: `rating` (1-5 emoji scale), `checknote` (checkbox + optional note), `shorttext` and `journal` (free-text daily entries). These are additive and only send a new optional `textValue` field on completions — they degrade gracefully (checkbox-like completion state still works) until the backend adds support. See the companion backend PR/prompt for the schema changes this unlocks.
- **New page: Achievements** — streak/completion milestone badges computed client-side from existing habit/completion data, no backend changes needed.
- **New page: History** — a GitHub-style contribution heatmap per habit.
- **Habits page**: search/type filter bar, a "show archived" toggle, and a quick-add template gallery (Drink Water, Exercise, Journal, etc.) in the New Habit modal.
- **Habit archiving/pausing**: Archive/Unarchive button in the edit modal instead of only hard-delete. Sends `archived` in the update payload so it starts persisting the moment the backend adds the column — no further frontend changes needed once that lands.
- **Settings**: export your habits + completions as JSON or CSV (fully client-side), and optional browser-notification reminders for incomplete habits (configurable time, local to the browser tab — no backend/push infra).
- Streak badges (added in the previous PR) now compute correctly across all 8 habit types.

## Backend dependency
This PR is designed to work today with **zero** backend changes (new fields are optional/ignored gracefully). Two small additive backend changes unlock full persistence for the new features:
1. Nullable `text_value` TEXT column on `completions`, read/write in the completion endpoints.
2. `archived BOOLEAN NOT NULL DEFAULT false` column on `habits`, read/write in the habit endpoints.

I've shared the exact prompt for this with the project owner to run against the separate backend repo.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm run lint` introduces zero new errors vs. the pre-existing baseline (only additional warnings matching an already-established codebase pattern)
- [x] Manually verified in-browser: all 4 new habit types render/interact correctly in both light and dark themes (verified via temporary placeholder data), Achievements and History pages render for both logged-out and structurally for logged-in states, nav wiring for the 2 new tabs
- [ ] Recommend a manual pass against a live backend once the schema changes land, to confirm text/archived values persist across reloads
